### PR TITLE
feat: Agent Trace v0.1.0 export + import (v0.3.9)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "selvedge",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Long-term memory for AI-coded codebases. A local MCP server that captures the why behind every change agents make, then reads it back: with prior_attempts, the agent checks 'was this tried here before, and how did it turn out?' before it edits. git blame for semantic entities (DB columns, functions, env vars, deps). Local SQLite, no LLM calls.",
   "author": {
     "name": "Mason Delan",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,59 @@ Selvedge uses [semantic versioning](https://semver.org/).
 
 ---
 
+## [0.3.9] — 2026-06-22
+
+**Agent Trace export — Selvedge is a compatible producer.** New
+`selvedge export --format agent-trace` emits
+[Agent Trace](https://github.com/cursor/agent-trace) **v0.1.0** records (the
+open AI code-attribution wire format from Cursor + Cognition AI), so Selvedge's
+captured history travels to any tool that reads the standard. Selvedge's
+reasoning and entity-level provenance ride along in each record's `metadata`
+under the reverse-domain `dev.selvedge` namespace — Agent Trace is the wire
+format, Selvedge is the live capture + query layer that emits it.
+
+**Pulled forward, deliberately.** The export was planned for v0.4.0 (Phase 3).
+It ships now, in the 0.3.x line, as an **opt-in, additive** interop format —
+nothing about the native model, MCP surface, or SQLite storage changes.
+Postgres and the HTTP layer remain the v0.4.0 markers; only the exporter moved
+up. **Drop-in upgrade for anyone on 0.3.8.**
+
+### Added
+
+- **`selvedge export --format agent-trace`** — one Agent Trace v0.1.0 record per
+  change event. `--ndjson` streams one record per line for large histories;
+  `--collapse-by-session` merges events sharing a `session_id` into a single
+  record. The default JSON form is a self-describing bundle
+  (`{agent_trace_version, producer, note, records: [...]}`).
+- **`selvedge import --format agent-trace`** — round-trips a Selvedge export
+  losslessly (entity, change type, and reasoning survive in `dev.selvedge`
+  metadata) and ingests foreign producers best-effort (`change_type="modify"`,
+  empty reasoning).
+- **`selvedge.exporters.agent_trace`** — the pure, dependency-free, no-LLM
+  converter behind both CLI directions (`event_to_trace_record`,
+  `trace_record_to_event`, `extract_line_ranges`, `events_to_trace_records`,
+  `validate_trace_record`). Plus a vendored v0.1.0 JSON Schema
+  (`selvedge/exporters/agent_trace_schema.json`) for reference.
+
+### Notes
+
+- **Conforms to the real v0.1.0 spec.** Records use
+  `files[].conversations[].ranges[]`, a `contributor` of type `ai`/`unknown`
+  (no `model_id` is fabricated — Selvedge stores the agent name, not a
+  models.dev id), `tool = {name: "selvedge", ...}`, and `vcs` from `git_commit`.
+- **Honest fidelity.** Entity-level events (DB column, env var, dependency) and
+  migration-imported events have no line range, so they carry
+  `metadata.dev.selvedge.range_unknown: true` and an empty `files[]` rather than
+  a fabricated `[1, 1]` placeholder. The export bundle's preamble explains this
+  to consumers up front.
+- **Test budget.** Adds `tests/test_agent_trace_export.py` (25 tests: round-trip,
+  non-file entity preservation, line-range extraction, collapse-by-session,
+  reasoning-quality passthrough, schema validation, and CLI integration). The
+  `docs/agent-trace-interop.md` mapping was corrected to the real v0.1.0 shape
+  (the earlier draft predated the published spec).
+
+---
+
 ## [0.3.8] — 2026-06-16
 
 **Active memory v1 (date-based).** Selvedge's append-only log learns to know

--- a/README.md
+++ b/README.md
@@ -117,6 +117,33 @@ made.** The diff is git's job. The why is Selvedge's.
 
 ---
 
+## What's new in v0.3.9
+
+**Agent Trace export — Selvedge is a compatible producer.**
+`selvedge export --format agent-trace` emits
+[Agent Trace](https://github.com/cursor/agent-trace) **v0.1.0** records — the
+open AI code-attribution wire format from Cursor + Cognition AI — so your
+captured history travels to any tool that reads the standard. Selvedge's
+reasoning and entity-level provenance ride along in each record's `metadata`
+under the `dev.selvedge` namespace. **Drop-in upgrade for anyone on 0.3.8.**
+
+```bash
+selvedge export --format agent-trace -o trace.json            # one record per event
+selvedge export --format agent-trace --ndjson -o trace.ndjson # stream, one per line
+selvedge export --format agent-trace --collapse-by-session    # merge a session into one record
+selvedge import trace.json --format agent-trace               # round-trip back in
+```
+
+It's **opt-in and additive** — nothing about the native model, the 8 MCP tools,
+or local SQLite changes. Entity-level events (a column, an env var, a
+dependency) have no line range, so Selvedge marks them
+`metadata.dev.selvedge.range_unknown: true` rather than fabricating one — an
+honest fidelity signal. This was planned for v0.4.0; only the exporter moved
+forward (Postgres + the HTTP layer remain the v0.4.0 markers). Full mapping in
+[`docs/agent-trace-interop.md`](docs/agent-trace-interop.md).
+
+---
+
 ## What's new in v0.3.8
 
 **Active memory v1 (date-based).** Selvedge's append-only log learns to know
@@ -181,89 +208,6 @@ called-out test-budget overage from the bundled CLI + agent-block work.
 
 ---
 
-## What's new in v0.3.7
-
-The brand-defining release: **`prior_attempts`** — the tool that lets an
-agent ask "was this tried before, and how did it turn out?" *before* it
-starts — plus the **entity-canonicalization foundation** it sits on.
-**Drop-in upgrade for anyone on 0.3.6.**
-
-### `prior_attempts` — the wedge
-
-Given an entity (or a free-text description), `prior_attempts` returns the
-prior change attempts on it, each annotated with an **inferred outcome**
-(`reverted` / `active`), a **confidence** tier, and — for reverted attempts —
-the reasoning explaining *why it was rejected*. Outcome is inferred from
-add→remove proximity (no LLM, ever — it's a templated query over reasoning
-the agents wrote live).
-
-Worked example — an agent about to re-add a column it doesn't know was
-already pulled:
-
-```jsonc
-// The agent is asked to keep mobile users signed in across restarts. Its
-// instinct is to add a persistent token column. It checks FIRST:
-prior_attempts({ "entity_path": "users.auth_token" })
-
-// → one high-confidence hit: this was tried and reverted.
-[
-  {
-    "entity_path": "users.auth_token",
-    "change_type": "add",
-    "reasoning": "Store a per-user auth token so the app stays signed in.",
-    "outcome": "reverted",
-    "confidence": "proximity_high",
-    "outcome_reasoning": "Reverted: DB tokens couldn't be revoked without a write; moved to short-lived JWTs."
-  }
-]
-```
-
-The agent reads the rejection reason and **changes its plan** — a
-refresh-token endpoint on the stateless-JWT path, instead of re-introducing
-the column the team already pulled. Full
-[demo transcript](docs/demos/prior-attempts.md).
-
-**Conservative by design.** `min_confidence` defaults to `proximity_high`,
-so `prior_attempts` only returns the clear "tried, then reverted" signal —
-an empty list is the trustworthy "nothing to worry about" answer, not noise.
-Pass `min_confidence="proximity_low"` to widen recall. Pull-only: the agent
-decides when to ask. This is the
-["alternatives tried, rejected paths"](docs/comparison.html) capability the
-line-attribution tools don't have.
-
-### Entity foundation (lands first)
-
-`prior_attempts` is only as good as the entity matching under it, so v0.3.7
-fixes the silent history-split problem first:
-
-- **Canonicalization on write.** `src/auth.py::login` and
-  `./src/auth.py::login` used to resolve to *different* entities. Now every
-  write goes through one chokepoint that strips `./`, collapses `//`,
-  normalizes separators, and trims — **preserving case on purpose**
-  (filesystems differ; silently lowercasing would collapse genuinely distinct
-  entities on case-sensitive Linux). `selvedge doctor` warns on sibling paths
-  that differ only by case instead of merging them.
-- **`selvedge migrate-paths`** backfills existing rows. **Dry-run is the
-  default** — it prints a collisions report (pre-canonicalization paths that
-  would merge) so you inspect before committing; pass `--apply` to write.
-  Idempotent, with an audit row per run.
-- **Renames, folded into `log_change`.** Pass `rename_from` with
-  `change_type="rename"` and Selvedge records the dual-event pattern (a
-  rename on the old path, a create on the new path with
-  `metadata.renamed_from`) so history follows the entity. No new tool.
-- **Soft entity-path shape warnings** — a `function` path without `::`, a
-  `column` without `.`, a `file` without a separator or extension get a
-  nudge, never a rejection.
-
-`prior_attempts` is the **7th** MCP tool (the only one this release adds);
-the grouped-digest helper ships as a `selvedge.aggregates.summary()` library
-function, not a tool. See [`CHANGELOG.md`](CHANGELOG.md) for the full list,
-including the 47 new tests — a called-out overrun of the ≤30 per-phase budget
-(≤40 phase target) because the entity foundation and the wedge ship together
-and a review pass hardened the acceptance-criteria edges.
-
----
-
 ## Where Selvedge fits
 
 <p align="center">
@@ -321,8 +265,10 @@ broken into eight smaller ones over a month.
 (Cursor + Cognition AI, RFC Jan 2026, backed by Cloudflare, Vercel, Google
 Jules, Amp, OpenCode, and git-ai) is an emerging *open standard* for AI
 code attribution traces. Selvedge isn't a competitor to it — it's a
-compatible producer. The design for `selvedge export --format agent-trace`
-is at [`docs/agent-trace-interop.md`](docs/agent-trace-interop.md). Agent
+compatible producer. As of **v0.3.9**, `selvedge export --format agent-trace`
+emits Agent Trace v0.1.0 records (and `selvedge import --format agent-trace`
+reads them back); the mapping is in
+[`docs/agent-trace-interop.md`](docs/agent-trace-interop.md). Agent
 Trace is the wire format. Selvedge is the live capture + query layer that
 emits it.
 
@@ -540,13 +486,17 @@ selvedge install-hook [--path PATH]       Install git post-commit hook
                      [--window MIN]       (default 60 minutes)
 selvedge backfill-commit --hash HASH      Backfill git_commit on recent events
                         [--window MIN]    (default 60 minutes)
-selvedge import PATH                      Import migration files (SQL / Alembic)
-              [--format auto|sql|alembic]
+selvedge import PATH                      Import migrations (SQL / Alembic) or
+              [--format auto|sql|         an Agent Trace file (agent-trace)
+                 alembic|agent-trace]
               [--project NAME]
               [--dry-run]
-selvedge export [--format json|csv]       Export history to JSON or CSV
+selvedge export [--format json|csv|       Export history (agent-trace =
+                 agent-trace]              Agent Trace v0.1.0 records)
               [--since SINCE]
               [--entity ENTITY]
+              [--ndjson]                  agent-trace: one record per line
+              [--collapse-by-session]     agent-trace: merge a session into one
               [--output FILE]
 selvedge log ENTITY CHANGE_TYPE           Manually log a change
              [--diff TEXT]                CHANGE_TYPE: add, remove, modify,

--- a/docs/agent-trace-interop.md
+++ b/docs/agent-trace-interop.md
@@ -1,11 +1,17 @@
 # Selvedge ↔ Agent Trace interop — design doc
 
-**Status:** Design.  Target version: **v0.4.0** (Phase 3, alongside the
-PostgreSQL backend).  Owner: maintainer.
+**Status:** Shipped in **v0.3.9** — pulled forward from the v0.4.0 plan as an
+opt-in interop format (Postgres + HTTP remain the v0.4.0 markers).  Owner:
+maintainer.
 
-> *This is a design proposal, not shipped functionality. The flag described
-> below does not exist yet — see "Implementation plan" at the bottom for
-> the work needed to land it.*
+> *`selvedge export --format agent-trace` and `selvedge import --format
+> agent-trace` exist as of v0.3.9. The shipped implementation conforms to the
+> **real** Agent Trace v0.1.0 record shape
+> (`files[].conversations[].ranges[]`, a `tool`/`vcs`/`metadata` envelope, and
+> Selvedge data under the reverse-domain `metadata["dev.selvedge"]` namespace).
+> That differs from this doc's **original draft mapping** below — the draft
+> predated the published spec. `selvedge/exporters/agent_trace.py` is the
+> source of truth; the corrected wire format and mapping table follow.*
 
 ## Why interop with Agent Trace at all
 
@@ -48,52 +54,55 @@ is purely an export format.
 ## Mapping: ChangeEvent → Agent Trace
 
 Per the [v0.1.0 Agent Trace spec](https://github.com/cursor/agent-trace),
-a trace record is JSON with:
+a trace record is JSON with this shape (line ranges live *inside* a file's
+`conversations[]`, and vendor data lives in `metadata` under reverse-domain
+keys — there is no top-level `contributors[]` or `extensions`):
 
 ```json
 {
   "version": "0.1.0",
   "id": "<uuid>",
-  "timestamp": "<iso8601>",
+  "timestamp": "<rfc3339>",
   "vcs": { "type": "git", "revision": "<sha>" },
-  "tool": { "name": "<name>", "version": "<v>" },
+  "tool": { "name": "selvedge", "version": "<v>" },
   "files": [
     {
       "path": "<repo-relative path>",
-      "ranges": [
+      "conversations": [
         {
-          "lines": "[start, end]",
-          "contributor": "<id from contributors[]>",
-          "conversation": "<id>",
-          "contentHash": "<optional sha256 of the line range>"
+          "url": "<uri>",
+          "contributor": { "type": "ai", "model_id": "<optional models.dev id>" },
+          "ranges": [ { "start_line": 42, "end_line": 67, "content_hash": "<optional>" } ],
+          "related": [ { "type": "<kind>", "url": "<uri>" } ]
         }
       ]
     }
   ],
-  "contributors": [
-    { "id": "<id>", "type": "ai|human|mixed|unknown", "model": "<model>" }
-  ],
-  "extensions": {}
+  "metadata": { "dev.selvedge": { } }
 }
 ```
 
-The mapping from a `ChangeEvent`:
+The shipped mapping from a `ChangeEvent`:
 
 | ChangeEvent field | Agent Trace target |
 |---|---|
-| `id` | top-level `id` (one trace record per event) |
+| `id` | top-level `id` (already a UUID; one record per event) |
 | `timestamp` | top-level `timestamp` |
-| `git_commit` | `vcs.revision` |
-| `agent` | `contributors[0].id` and a `model` lookup table; `type: "ai"` if known |
-| `entity_path` *(file-typed)* | `files[].path` |
-| `entity_path` *(non-file: column, env, dep, route)* | `extensions.selvedge.entity` (no native Agent Trace concept) |
-| `change_type` | `extensions.selvedge.change_type` |
-| `diff` | `files[].ranges[].contentHash` (sha256 of the affected text) + `extensions.selvedge.diff` (raw) |
-| `reasoning` | `extensions.selvedge.reasoning` |
-| `session_id` | `extensions.selvedge.session_id` |
-| `changeset_id` | `extensions.selvedge.changeset_id` |
-| `project` | `extensions.selvedge.project` |
-| `metadata` | merged into `extensions.selvedge.metadata` |
+| `git_commit` | `vcs.revision` (`vcs.type = "git"`); omitted when empty |
+| *(producer identity)* | `tool = { name: "selvedge", version }` |
+| `agent` | `files[].conversations[].contributor.type` (`ai` if present, else `unknown`); the agent *name* → `metadata["dev.selvedge"].agent`. `model_id` is **not** fabricated — Selvedge stores an agent name, not a models.dev id |
+| `entity_path` *(file-typed: file/function/class)* | `files[].path` (a `path::symbol` is stripped to the file) |
+| `diff` | `files[].conversations[].ranges[]` via unified-diff hunk extraction |
+| `entity_path` *(non-file: column, env, dep, route)* | `metadata["dev.selvedge"].entity` only; `files[]` is empty (no native Agent Trace concept) |
+| `change_type` | `metadata["dev.selvedge"].change_type` |
+| `reasoning` | `metadata["dev.selvedge"].reasoning` |
+| `session_id` | `metadata["dev.selvedge"].session_id` (also the `conversations[].url` urn) |
+| `changeset_id` | `metadata["dev.selvedge"].changeset_id` (also a `conversations[].related[]` urn) |
+| `project` | `metadata["dev.selvedge"].project` |
+| `metadata` | merged into `metadata["dev.selvedge"].metadata` |
+
+> The prose further down this doc that says `extensions.selvedge.*` reflects the
+> original draft; in the shipped format read it as `metadata["dev.selvedge"].*`.
 
 ### Handling non-file entities
 
@@ -197,21 +206,22 @@ A new `tests/test_agent_trace_export.py`:
    `extensions.selvedge.reasoning` unmodified, with the same warning the
    validator currently emits at log time.
 
-## Implementation plan
+## Implementation status — shipped in v0.3.9
 
-Estimated 1–1.5 days of work, broken into incremental PRs:
+All of the originally-planned work landed together in v0.3.9:
 
-1. **PR 1 (0.5 day)** — Add `selvedge.exporters.agent_trace` module with
-   pure conversion: `ChangeEvent → dict (AT v0.1.0)` and the inverse.
-   Unit tests on the mapping table only — no CLI yet, no file I/O.
-2. **PR 2 (0.5 day)** — Wire `--format agent-trace` and `--ndjson` into
-   `selvedge export`. Wire `--format agent-trace` into `selvedge import`
-   (round-trip test gates the merge).
-3. **PR 3 (0.5 day)** — Diff-to-line-range extractor for unified diffs;
-   `--collapse-by-session` flag; vendored AT v0.1.0 JSON schema +
-   schema-validation test.
+1. **`selvedge.exporters.agent_trace`** — pure, dependency-free, no-LLM
+   conversion both ways (`event_to_trace_record` / `trace_record_to_event`),
+   plus `extract_line_ranges`, `events_to_trace_records`, `load_trace_records`,
+   and a hand-rolled `validate_trace_record` (no `jsonschema` dependency).
+2. **CLI** — `selvedge export --format agent-trace` with `--ndjson` and
+   `--collapse-by-session`; `selvedge import --format agent-trace` (round-trip
+   gated by tests).
+3. **Diff-to-line-range extractor** for unified diffs; vendored AT v0.1.0 JSON
+   Schema at `selvedge/exporters/agent_trace_schema.json`;
+   `tests/test_agent_trace_export.py` (25 tests).
 
-Lands in v0.4.0 alongside the PostgreSQL backend (Phase 3 in `CLAUDE.md`).
+Pulled forward from the v0.4.0 plan; Postgres + HTTP remain the v0.4.0 markers.
 
 ## Open questions
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "selvedge",
   "display_name": "Selvedge",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Long-term memory for AI-coded codebases. A local MCP server that captures the why behind every change agents make, then reads it back: with prior_attempts, the agent checks 'was this tried here before, and how did it turn out?' before it edits. git blame for semantic entities (DB columns, functions, env vars, deps). Local SQLite, no LLM calls.",
   "long_description": "Selvedge is an MCP server that AI coding agents call as they work to log structured change events. It captures the entity (DB column, table, function, endpoint, dependency, env var), the diff, and the reasoning \u2014 the intent that would otherwise evaporate when the agent session ends.\n\nWith human-written code, intent leaked into commit messages and PR descriptions. With AI-written code, intent lives in a prompt that disappears. Selvedge writes it down before it's gone, so weeks later you can ask 'when was users.stripe_customer_id added and why?' and get a real answer.\n\nThe SQLite DB lives locally in `.selvedge/` next to your code \u2014 your data stays yours.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "selvedge"
-version = "0.3.8"
+version = "0.3.9"
 description = "Change tracking for AI-era codebases"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/selvedge/__init__.py
+++ b/selvedge/__init__.py
@@ -30,7 +30,7 @@ from .validation import (
     check_reasoning_quality,
 )
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"
 
 __all__ = [
     # Version

--- a/selvedge/cli.py
+++ b/selvedge/cli.py
@@ -1869,23 +1869,36 @@ def backfill_commit(commit_hash, window, quiet):
 
 
 @cli.command()
-@click.option("--format", "fmt", type=click.Choice(["json", "csv"]), default="json",
+@click.option("--format", "fmt",
+              type=click.Choice(["json", "csv", "agent-trace"]), default="json",
               show_default=True, help="Output format")
 @click.option("--since", "-s", default="", help=_SINCE_HELP)
 @click.option("--entity", "-e", default="", help="Filter to entity path prefix")
 @click.option("--project", "-p", default="", help="Filter by project name")
 @click.option("--limit", "-n", default=0, help="Max rows (0 = all)")
+@click.option("--ndjson", is_flag=True,
+              help="agent-trace only: one trace record per line (NDJSON)")
+@click.option("--collapse-by-session", "collapse", is_flag=True,
+              help="agent-trace only: merge events sharing a session_id into one record")
 @click.option("--output", "-o", default="-",
               help="Output file path (default: stdout)")
-def export(fmt, since, entity, project, limit, output):
-    """Export change history to JSON or CSV.
+def export(fmt, since, entity, project, limit, ndjson, collapse, output):
+    """Export change history to JSON, CSV, or Agent Trace.
 
     \b
     Examples:
       selvedge export                            # all events as JSON to stdout
       selvedge export --format csv -o out.csv   # CSV file
       selvedge export --since 30d --entity users
-      selvedge export --format json -o history.json
+      selvedge export --format agent-trace -o trace.json
+      selvedge export --format agent-trace --ndjson -o trace.ndjson
+      selvedge export --format agent-trace --collapse-by-session -o trace.json
+
+    \b
+    The agent-trace format emits Agent Trace v0.1.0 records
+    (https://github.com/cursor/agent-trace) — one per change event by default.
+    Selvedge is a compatible producer; reasoning and entity-level provenance
+    travel in each record's metadata under the "dev.selvedge" namespace.
     """
     import csv as csv_mod
     import io
@@ -1899,7 +1912,20 @@ def export(fmt, since, entity, project, limit, output):
         limit=effective_limit,
     )
 
-    if fmt == "json":
+    if fmt == "agent-trace":
+        from .exporters.agent_trace import (
+            SELVEDGE_NS,
+            events_to_trace_records,
+            export_preamble,
+        )
+
+        records = events_to_trace_records(rows, collapse_by_session=collapse)
+        if ndjson:
+            content = "\n".join(json.dumps(r) for r in records)
+        else:
+            header = export_preamble()[SELVEDGE_NS]
+            content = json.dumps({**header, "records": records}, indent=2)
+    elif fmt == "json":
         content = json.dumps(rows, indent=2)
     else:
         buf = io.StringIO()
@@ -1927,18 +1953,21 @@ def export(fmt, since, entity, project, limit, output):
 @cli.command("import")
 @click.argument("path", type=click.Path(exists=True))
 @click.option("--format", "fmt",
-              type=click.Choice(["auto", "sql", "alembic"]),
+              type=click.Choice(["auto", "sql", "alembic", "agent-trace"]),
               default="auto", show_default=True,
-              help="Migration format (auto-detects by default)")
+              help="Input format (auto-detects migrations by default)")
 @click.option("--project", "-p", default="", help="Project name to tag events with")
 @click.option("--dry-run", is_flag=True, help="Preview what would be imported, don't write")
 @click.option("--json", "as_json", is_flag=True, help="Output events as JSON (implies --dry-run)")
 def import_migrations(path, fmt, project, dry_run, as_json):
-    """Import migration files to backfill schema change history.
+    """Import migration files or an Agent Trace file to backfill history.
 
     \b
     PATH can be a single migration file or a directory of migration files.
-    Supports raw SQL DDL files and Alembic Python migration files.
+    Supports raw SQL DDL files and Alembic Python migration files. With
+    --format agent-trace, PATH is an Agent Trace JSON/NDJSON file (round-trips
+    a `selvedge export --format agent-trace`; foreign producers import
+    best-effort with change_type="modify" and empty reasoning).
 
     \b
     Examples:
@@ -1946,14 +1975,38 @@ def import_migrations(path, fmt, project, dry_run, as_json):
       selvedge import migrations/ --project my-api
       selvedge import migrations/0023_add_payments.py --dry-run
       selvedge import schema.sql --format sql
+      selvedge import trace.json --format agent-trace
     """
-    from .importers import import_path
-
     target = Path(path)
-    events = import_path(target, fmt=fmt, project=project)
+
+    if fmt == "agent-trace":
+        from .exporters.agent_trace import load_trace_records, trace_record_to_events
+        from .models import ChangeEvent
+
+        records = load_trace_records(target.read_text())
+        events = []
+        seen_ids: set[str] = set()
+        for record in records:
+            for event_dict in trace_record_to_events(record):
+                try:
+                    event = ChangeEvent(**event_dict)
+                except (ValueError, TypeError):
+                    continue
+                # Dedupe within the batch so a re-derived id can't abort the
+                # single-transaction insert on a PRIMARY KEY collision.
+                if event.id in seen_ids:
+                    continue
+                seen_ids.add(event.id)
+                if project:
+                    event.project = project
+                events.append(event)
+    else:
+        from .importers import import_path
+
+        events = import_path(target, fmt=fmt, project=project)
 
     if not events:
-        console.print("[yellow]No importable schema changes found.[/yellow]")
+        console.print("[yellow]No importable changes found.[/yellow]")
         return
 
     if as_json:

--- a/selvedge/exporters/__init__.py
+++ b/selvedge/exporters/__init__.py
@@ -1,0 +1,11 @@
+"""Export/import adapters that bridge Selvedge's native model to other formats.
+
+Currently:
+
+- :mod:`selvedge.exporters.agent_trace` — Agent Trace v0.1.0 producer/consumer
+  (the open AI-attribution wire format from Cursor + Cognition AI).
+
+These live outside the frozen top-level ``selvedge`` API surface on purpose:
+they are interop adapters, not core library types. Import them from the
+submodule (``from selvedge.exporters.agent_trace import ...``).
+"""

--- a/selvedge/exporters/agent_trace.py
+++ b/selvedge/exporters/agent_trace.py
@@ -1,0 +1,594 @@
+"""Selvedge ↔ Agent Trace v0.1.0 interop.
+
+`Agent Trace <https://github.com/cursor/agent-trace>`_ is the open AI
+code-attribution wire format published by Cursor and Cognition AI. Selvedge is
+a *compatible producer*: it already captures everything Agent Trace records
+(file/line attribution tied to an AI contributor) plus reasoning and
+entity-level provenance, so it can emit Agent Trace records that other tools
+read.
+
+This module is a pure, deterministic, dependency-free converter — no LLM, no
+I/O. The CLI (``selvedge export --format agent-trace`` /
+``selvedge import --format agent-trace``) is a thin shell over it.
+
+Mapping summary (``ChangeEvent`` dict → Agent Trace v0.1.0 record):
+
+============================  =========================================
+ChangeEvent field             Agent Trace target
+============================  =========================================
+``id``                        top-level ``id`` (already a UUID)
+``timestamp``                 top-level ``timestamp``
+``git_commit``                ``vcs.revision`` (``vcs.type = "git"``)
+*(producer identity)*         ``tool = {name: "selvedge", version}``
+``agent``                     ``files[].conversations[].contributor.type``
+                              (``ai``/``unknown``); name kept in metadata
+``entity_path`` *(file)*      ``files[].path`` (``path::symbol`` → ``path``)
+``diff``                      ``files[].conversations[].ranges`` (hunks)
+``entity_path`` *(non-file)*  ``metadata["dev.selvedge"].entity`` only
+everything else               ``metadata["dev.selvedge"].*``
+============================  =========================================
+
+Fidelity note: column / env-var / dependency events and migration-imported
+events have no line range, so the converter emits ``range_unknown: true`` in
+``metadata["dev.selvedge"]`` rather than fabricating a ``[1, 1]`` placeholder.
+See :func:`export_preamble`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import uuid
+from typing import Any
+
+from ..models import VALID_CHANGE_TYPES
+
+# Pinned to the Agent Trace spec version this module targets.
+AGENT_TRACE_VERSION = "0.1.0"
+
+# Reverse-domain namespace for Selvedge-specific data carried inside an Agent
+# Trace record's ``metadata`` object (the spec's recommended convention).
+SELVEDGE_NS = "dev.selvedge"
+
+# Stable namespace for deriving record IDs from non-UUID inputs.
+_ID_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_URL, "https://selvedge.sh/agent-trace")
+
+# Entity types whose ``entity_path`` denotes (or contains) a real file path.
+_FILE_ENTITY_TYPES = frozenset({"file", "function", "class"})
+
+# Unified-diff hunk header: capture the new-file start line and (optional) count.
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", re.MULTILINE)
+
+# Agent Trace contributor types.
+_CONTRIBUTOR_TYPES = frozenset({"human", "ai", "mixed", "unknown"})
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _selvedge_version() -> str:
+    """Return the installed Selvedge version (lazy import avoids a cycle)."""
+    try:
+        from selvedge import __version__
+
+        return __version__
+    except Exception:  # pragma: no cover - defensive
+        return "0"
+
+
+def _metadata_value(raw: Any) -> Any:
+    """Parse a ChangeEvent ``metadata`` value (JSON string or dict) to its value.
+
+    Preserves the original JSON type (dict, list, scalar) so a round-trip never
+    rewraps a list as ``{"value": [...]}``. Returns ``None`` for empty or
+    unparseable input so the caller can simply omit the key.
+    """
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def _record_id(raw: Any) -> str:
+    """Coerce a ChangeEvent id to a UUID string (deterministic if not already one)."""
+    try:
+        return str(uuid.UUID(str(raw)))
+    except (ValueError, AttributeError, TypeError):
+        return str(uuid.uuid5(_ID_NAMESPACE, str(raw)))
+
+
+def _is_file_entity(entity_type: str, entity_path: str) -> bool:
+    """Whether the entity maps onto a repo file path."""
+    if entity_type in _FILE_ENTITY_TYPES:
+        return True
+    # Heuristic fallback for events whose entity_type is "other" but whose path
+    # is clearly a file (contains a path separator and a dotted extension).
+    return "::" in entity_path or bool(re.search(r"/[^/]+\.[A-Za-z0-9]+$", entity_path))
+
+
+def _file_path(entity_path: str) -> str:
+    """Strip a ``::symbol`` suffix to get the bare file path."""
+    return entity_path.split("::", 1)[0]
+
+
+def extract_line_ranges(diff: str) -> list[dict]:
+    """Extract new-file line ranges from a unified diff's hunk headers.
+
+    Returns a list of ``{"start_line": int, "end_line": int}`` (both >= 1), one
+    per ``@@ -a,b +c,d @@`` hunk. Returns ``[]`` when the diff has no parseable
+    hunks (e.g. raw SQL DDL from ``selvedge import``).
+    """
+    ranges: list[dict] = []
+    for match in _HUNK_RE.finditer(diff or ""):
+        start = int(match.group(1))
+        count = int(match.group(2)) if match.group(2) is not None else 1
+        if start < 1 or count < 1:
+            continue
+        ranges.append({"start_line": start, "end_line": start + count - 1})
+    return ranges
+
+
+def _contributor(agent: str) -> dict:
+    """Build an Agent Trace contributor object from a Selvedge agent name.
+
+    Selvedge stores the agent/tool name (``claude-code``, ``cursor``), not a
+    models.dev model id, so ``model_id`` is intentionally omitted rather than
+    fabricated. An empty agent is reported as ``unknown``.
+    """
+    return {"type": "ai" if agent else "unknown"}
+
+
+def _selvedge_meta(event: dict) -> dict:
+    """The ``metadata["dev.selvedge"]`` payload for one event (lossless extras)."""
+    extra = _metadata_value(event.get("metadata"))
+    meta: dict[str, Any] = {
+        "entity": event.get("entity_path", ""),
+        "entity_type": event.get("entity_type", ""),
+        "change_type": event.get("change_type", ""),
+        "reasoning": event.get("reasoning", ""),
+        "agent": event.get("agent", ""),
+        "session_id": event.get("session_id", ""),
+        "changeset_id": event.get("changeset_id", ""),
+        "project": event.get("project", ""),
+    }
+    # Preserve the original metadata value (any JSON type) but skip empties.
+    if extra is not None and extra != {}:
+        meta["metadata"] = extra
+    return meta
+
+
+def _conversation(event: dict, ranges: list[dict]) -> dict:
+    """Build a conversation object linking the contributor to its line ranges."""
+    session_id = event.get("session_id", "")
+    ref = (
+        f"urn:selvedge:session:{session_id}"
+        if session_id
+        else f"urn:selvedge:event:{_record_id(event.get('id'))}"
+    )
+    conv: dict[str, Any] = {
+        "url": ref,
+        "contributor": _contributor(event.get("agent", "")),
+        "ranges": ranges,
+    }
+    changeset_id = event.get("changeset_id", "")
+    if changeset_id:
+        conv["related"] = [
+            {"type": "changeset", "url": f"urn:selvedge:changeset:{changeset_id}"}
+        ]
+    return conv
+
+
+# ---------------------------------------------------------------------------
+# ChangeEvent -> Agent Trace
+# ---------------------------------------------------------------------------
+
+
+def event_to_trace_record(event: dict, *, tool_version: str | None = None) -> dict:
+    """Convert one ChangeEvent dict to an Agent Trace v0.1.0 trace record.
+
+    ``event`` is a dict shaped like :meth:`selvedge.ChangeEvent.to_dict`.
+    """
+    tool_version = tool_version or _selvedge_version()
+    entity_path = event.get("entity_path", "")
+    entity_type = event.get("entity_type", "")
+    diff = event.get("diff", "")
+
+    record: dict[str, Any] = {
+        "version": AGENT_TRACE_VERSION,
+        "id": _record_id(event.get("id")),
+        "timestamp": event.get("timestamp", ""),
+        "tool": {"name": "selvedge", "version": tool_version},
+        "files": [],
+    }
+
+    git_commit = event.get("git_commit", "")
+    if git_commit:
+        record["vcs"] = {"type": "git", "revision": git_commit}
+
+    selvedge_meta = _selvedge_meta(event)
+
+    if _is_file_entity(entity_type, entity_path):
+        ranges = extract_line_ranges(diff)
+        record["files"] = [
+            {"path": _file_path(entity_path), "conversations": [_conversation(event, ranges)]}
+        ]
+        selvedge_meta["range_unknown"] = not ranges
+    else:
+        # Non-file entities (column, env var, dependency, route, …) have no path
+        # Agent Trace can represent. Keep them lossless in metadata; AT-only
+        # readers see an empty files[] rather than a fabricated path.
+        selvedge_meta["range_unknown"] = True
+
+    record["metadata"] = {SELVEDGE_NS: selvedge_meta}
+    return record
+
+
+def _collapsed_record(events: list[dict], tool_version: str) -> dict:
+    """Merge events sharing a session into one record (``--collapse-by-session``)."""
+    first = events[0]
+    session_id = first.get("session_id", "")
+    record: dict[str, Any] = {
+        "version": AGENT_TRACE_VERSION,
+        "id": str(uuid.uuid5(_ID_NAMESPACE, f"session:{session_id}")),
+        "timestamp": min(e.get("timestamp", "") for e in events),
+        "tool": {"name": "selvedge", "version": tool_version},
+        "files": [],
+    }
+    for event in events:
+        commit = event.get("git_commit", "")
+        if commit:
+            record["vcs"] = {"type": "git", "revision": commit}
+            break
+
+    files_by_path: dict[str, dict] = {}
+    per_event_meta: list[dict] = []
+    for event in events:
+        per_event_meta.append(_selvedge_meta(event))
+        entity_path = event.get("entity_path", "")
+        if _is_file_entity(event.get("entity_type", ""), entity_path):
+            path = _file_path(entity_path)
+            ranges = extract_line_ranges(event.get("diff", ""))
+            entry = files_by_path.setdefault(path, {"path": path, "conversations": []})
+            entry["conversations"].append(_conversation(event, ranges))
+
+    record["files"] = list(files_by_path.values())
+    record["metadata"] = {
+        SELVEDGE_NS: {
+            "session_id": session_id,
+            "collapsed": True,
+            "event_count": len(events),
+            "events": per_event_meta,
+        }
+    }
+    return record
+
+
+def events_to_trace_records(
+    events: list[dict],
+    *,
+    collapse_by_session: bool = False,
+    tool_version: str | None = None,
+) -> list[dict]:
+    """Convert a list of ChangeEvent dicts to Agent Trace records.
+
+    Default is 1:1 (one record per event). With ``collapse_by_session=True``,
+    events sharing a non-empty ``session_id`` are merged into a single record
+    (emitted at the position of the session's first event); events without a
+    session stay 1:1.
+    """
+    tool_version = tool_version or _selvedge_version()
+    if not collapse_by_session:
+        return [event_to_trace_record(e, tool_version=tool_version) for e in events]
+
+    sessions: dict[str, list[dict]] = {}
+    order: list[tuple[str, str]] = []  # (kind, key) preserving first-seen order
+    singles: dict[str, dict] = {}
+    for idx, event in enumerate(events):
+        sid = event.get("session_id") or ""
+        if sid:
+            if sid not in sessions:
+                sessions[sid] = []
+                order.append(("session", sid))
+            sessions[sid].append(event)
+        else:
+            key = f"single:{idx}"
+            singles[key] = event
+            order.append(("single", key))
+
+    records: list[dict] = []
+    for kind, key in order:
+        if kind == "session":
+            records.append(_collapsed_record(sessions[key], tool_version))
+        else:
+            records.append(event_to_trace_record(singles[key], tool_version=tool_version))
+    return records
+
+
+def export_preamble(tool_version: str | None = None) -> dict:
+    """A non-record header describing the producer and its fidelity profile.
+
+    Emitted as the first element of the JSON-array export so Agent Trace
+    consumers know that ``range_unknown: true`` records are a truthful
+    representation of entity-level / migration-imported events, not a
+    low-fidelity producer.
+    """
+    tool_version = tool_version or _selvedge_version()
+    return {
+        SELVEDGE_NS: {
+            "producer": f"selvedge {tool_version}",
+            "agent_trace_version": AGENT_TRACE_VERSION,
+            "note": (
+                "Selvedge emits one Agent Trace record per change event. Records "
+                "with metadata.dev.selvedge.range_unknown=true are entity-level "
+                "(DB column, env var, dependency) or migration-imported events "
+                "that genuinely have no line range — not low-fidelity output."
+            ),
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Agent Trace -> ChangeEvent  (best-effort import)
+# ---------------------------------------------------------------------------
+
+
+def load_trace_records(text: str) -> list[dict]:
+    """Parse Agent Trace records from any shape Selvedge's export can emit.
+
+    Accepts: a Selvedge bundle object (``{"records": [...]}``), a bare JSON
+    array of records, a single record object (has ``version`` + ``files``), or
+    NDJSON (one record per line). Returns the list of record dicts.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return []
+    try:
+        parsed = json.loads(stripped)
+    except ValueError:
+        # NDJSON fallback: one JSON record per non-empty line.
+        records = []
+        for line in stripped.splitlines():
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+        return records
+    if isinstance(parsed, dict):
+        if isinstance(parsed.get("records"), list):
+            return parsed["records"]
+        return [parsed]
+    if isinstance(parsed, list):
+        return parsed
+    return []
+
+
+def _coerce_change_type(raw: Any) -> str:
+    """Map a change_type to a valid one, defaulting unknown values to ``modify``.
+
+    Mirrors ChangeEvent's tolerance: a foreign/hand-edited record with an
+    unknown verb (``"edit"``) imports as ``modify`` instead of being silently
+    dropped when ChangeEvent rejects it.
+    """
+    ct = raw or "modify"
+    return ct if ct in VALID_CHANGE_TYPES else "modify"
+
+
+def _event_from_selvedge_meta(record: dict, sv: dict, idx: int | None = None) -> dict | None:
+    """Reconstruct one ChangeEvent dict from a ``dev.selvedge`` per-event block."""
+    entity_path = sv.get("entity", "")
+    if not entity_path:
+        return None
+    base_id = record.get("id")
+    rid = _record_id(f"{base_id}:{idx}") if idx is not None else _record_id(base_id)
+    mv = sv.get("metadata")
+    return {
+        "id": rid,
+        "timestamp": record.get("timestamp", ""),
+        "entity_type": sv.get("entity_type") or "other",
+        "entity_path": entity_path,
+        "change_type": _coerce_change_type(sv.get("change_type")),
+        "diff": "",
+        "reasoning": sv.get("reasoning", ""),
+        "agent": sv.get("agent", ""),
+        "session_id": sv.get("session_id", ""),
+        "git_commit": (record.get("vcs") or {}).get("revision", ""),
+        "project": sv.get("project", ""),
+        "changeset_id": sv.get("changeset_id", ""),
+        "metadata": json.dumps(mv) if mv is not None else "{}",
+    }
+
+
+def trace_record_to_events(record: dict) -> list[dict]:
+    """Convert one Agent Trace record to zero or more ChangeEvent dicts.
+
+    - A Selvedge **collapsed** record (`--collapse-by-session` export, marked
+      ``metadata.dev.selvedge.collapsed``) fans back out to one event per entry
+      in its ``events`` list — so a collapsed export round-trips losslessly.
+    - A single Selvedge record (``metadata.dev.selvedge.entity``) yields one
+      lossless event.
+    - A **foreign** record yields one event per file in ``files[]`` (Agent Trace
+      is a file-array format), each ``change_type="modify"`` with empty
+      reasoning and an ``ai``/empty agent from that file's contributor.
+
+    Every reconstructed event gets a deterministic id derived from the record id
+    and the entity/file, so an id-less or multi-file record can't collide on the
+    primary key when imported. Returns ``[]`` for a record with no usable entity.
+    """
+    meta = record.get("metadata") or {}
+    sv = meta.get(SELVEDGE_NS) if isinstance(meta, dict) else None
+
+    # Collapsed Selvedge record → fan out to its per-event metadata.
+    if isinstance(sv, dict) and sv.get("collapsed") and isinstance(sv.get("events"), list):
+        events: list[dict] = []
+        for i, em in enumerate(sv["events"]):
+            if not isinstance(em, dict):
+                continue
+            ev = _event_from_selvedge_meta(record, em, idx=i)
+            if ev is not None:
+                ev["session_id"] = ev["session_id"] or sv.get("session_id", "")
+                events.append(ev)
+        return events
+
+    # Single Selvedge record → one lossless event.
+    if isinstance(sv, dict) and sv.get("entity"):
+        ev = _event_from_selvedge_meta(record, sv)
+        return [ev] if ev is not None else []
+
+    # Foreign record → one event per file (file-array format).
+    foreign: list[dict] = []
+    base_id = record.get("id")
+    commit = (record.get("vcs") or {}).get("revision", "")
+    for f in record.get("files") or []:
+        if not (isinstance(f, dict) and f.get("path")):
+            continue
+        path = f["path"]
+        contributor_type = ""
+        for conv in f.get("conversations") or []:
+            ctype = (conv.get("contributor") or {}).get("type")
+            if ctype:
+                contributor_type = ctype
+                break
+        foreign.append({
+            "id": _record_id(f"{base_id}::{path}"),
+            "timestamp": record.get("timestamp", ""),
+            "entity_type": "file",
+            "entity_path": path,
+            "change_type": "modify",
+            "diff": "",
+            "reasoning": "",
+            "agent": "ai" if contributor_type == "ai" else "",
+            "session_id": "",
+            "git_commit": commit,
+            "project": "",
+            "changeset_id": "",
+            "metadata": "{}",
+        })
+    return foreign
+
+
+def trace_record_to_event(record: dict) -> dict | None:
+    """Single-event view of :func:`trace_record_to_events` (first event or ``None``).
+
+    Prefer :func:`trace_record_to_events`, which correctly expands collapsed and
+    multi-file records into all of their events.
+    """
+    events = trace_record_to_events(record)
+    return events[0] if events else None
+
+
+# ---------------------------------------------------------------------------
+# validation (no third-party jsonschema dependency)
+# ---------------------------------------------------------------------------
+
+
+def validate_trace_record(record: Any) -> list[str]:
+    """Structurally validate a record against Agent Trace v0.1.0.
+
+    Returns a list of human-readable problems; an empty list means valid. This
+    is a hand-rolled checker (Selvedge takes no jsonschema dependency) covering
+    the spec's required fields, types, and enums. ``content_hash`` of a range is
+    treated as optional, matching the spec.
+    """
+    problems: list[str] = []
+    if not isinstance(record, dict):
+        return ["record is not an object"]
+
+    if record.get("version") != AGENT_TRACE_VERSION:
+        problems.append(f"version must be {AGENT_TRACE_VERSION!r}")
+    if not isinstance(record.get("id"), str) or not record.get("id"):
+        problems.append("id must be a non-empty string")
+    else:
+        try:
+            uuid.UUID(record["id"])
+        except ValueError:
+            problems.append("id must be a UUID")
+    if not isinstance(record.get("timestamp"), str) or not record.get("timestamp"):
+        problems.append("timestamp must be a non-empty string")
+
+    vcs = record.get("vcs")
+    if vcs is not None:
+        if not isinstance(vcs, dict):
+            problems.append("vcs must be an object")
+        else:
+            if vcs.get("type") not in {"git", "jj", "hg", "svn"}:
+                problems.append("vcs.type must be one of git/jj/hg/svn")
+            if not isinstance(vcs.get("revision"), str) or not vcs.get("revision"):
+                problems.append("vcs.revision must be a non-empty string")
+
+    tool = record.get("tool")
+    if tool is not None and not isinstance(tool, dict):
+        problems.append("tool must be an object")
+
+    files = record.get("files")
+    if not isinstance(files, list):
+        problems.append("files must be an array")
+    else:
+        for i, f in enumerate(files):
+            problems.extend(_validate_file(f, i))
+
+    if "metadata" in record and not isinstance(record["metadata"], dict):
+        problems.append("metadata must be an object")
+
+    return problems
+
+
+def _validate_file(f: Any, i: int) -> list[str]:
+    """Validate one ``files[]`` entry (and its conversations/ranges)."""
+    problems: list[str] = []
+    if not isinstance(f, dict):
+        return [f"files[{i}] must be an object"]
+    if not isinstance(f.get("path"), str) or not f.get("path"):
+        problems.append(f"files[{i}].path must be a non-empty string")
+    convs = f.get("conversations", [])
+    if not isinstance(convs, list):
+        problems.append(f"files[{i}].conversations must be an array")
+        return problems
+    for j, conv in enumerate(convs):
+        loc = f"files[{i}].conversations[{j}]"
+        if not isinstance(conv, dict):
+            problems.append(f"{loc} must be an object")
+            continue
+        # Per spec, `contributor` is OPTIONAL on a conversation (it can be set
+        # per-range instead); validate its shape only when present.
+        contributor = conv.get("contributor")
+        if contributor is not None:
+            if not isinstance(contributor, dict):
+                problems.append(f"{loc}.contributor must be an object")
+            elif contributor.get("type") not in _CONTRIBUTOR_TYPES:
+                problems.append(f"{loc}.contributor.type must be one of {sorted(_CONTRIBUTOR_TYPES)}")
+        # `ranges` is REQUIRED on a conversation per the spec.
+        if "ranges" not in conv:
+            problems.append(f"{loc}.ranges is required")
+            continue
+        ranges = conv.get("ranges")
+        if not isinstance(ranges, list):
+            problems.append(f"{loc}.ranges must be an array")
+            continue
+        for k, rng in enumerate(ranges):
+            if not isinstance(rng, dict):
+                problems.append(f"{loc}.ranges[{k}] must be an object")
+                continue
+            range_contributor = rng.get("contributor")
+            if range_contributor is not None:
+                if not isinstance(range_contributor, dict):
+                    problems.append(f"{loc}.ranges[{k}].contributor must be an object")
+                elif range_contributor.get("type") not in _CONTRIBUTOR_TYPES:
+                    problems.append(
+                        f"{loc}.ranges[{k}].contributor.type must be one of {sorted(_CONTRIBUTOR_TYPES)}"
+                    )
+            for bound in ("start_line", "end_line"):
+                val = rng.get(bound)
+                if not isinstance(val, int) or isinstance(val, bool) or val < 1:
+                    problems.append(f"{loc}.ranges[{k}].{bound} must be an integer >= 1")
+    return problems
+
+
+def content_hash(text: str) -> str:
+    """A stable ``algo:hex`` content hash, for callers that want one on a range."""
+    return "sha256:" + hashlib.sha256((text or "").encode("utf-8")).hexdigest()

--- a/selvedge/exporters/agent_trace_schema.json
+++ b/selvedge/exporters/agent_trace_schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://selvedge.sh/schemas/agent-trace-0.1.0.json",
+  "title": "Agent Trace Record v0.1.0",
+  "description": "Vendored copy of the Agent Trace v0.1.0 trace-record schema (https://github.com/cursor/agent-trace). Reference + documentation; Selvedge validates with the dependency-free selvedge.exporters.agent_trace.validate_trace_record().",
+  "type": "object",
+  "required": ["version", "id", "timestamp", "files"],
+  "additionalProperties": true,
+  "properties": {
+    "version": { "type": "string" },
+    "id": { "type": "string", "format": "uuid" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "vcs": {
+      "type": "object",
+      "required": ["type", "revision"],
+      "properties": {
+        "type": { "enum": ["git", "jj", "hg", "svn"] },
+        "revision": { "type": "string" }
+      }
+    },
+    "tool": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" }
+      }
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "conversations"],
+        "properties": {
+          "path": { "type": "string" },
+          "conversations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["ranges"],
+              "properties": {
+                "url": { "type": "string" },
+                "contributor": { "$ref": "#/$defs/contributor" },
+                "ranges": {
+                  "type": "array",
+                  "items": { "$ref": "#/$defs/range" }
+                },
+                "related": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "type": { "type": "string" },
+                      "url": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "metadata": { "type": "object" }
+  },
+  "$defs": {
+    "contributor": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "enum": ["human", "ai", "mixed", "unknown"] },
+        "model_id": { "type": "string", "maxLength": 250 }
+      }
+    },
+    "range": {
+      "type": "object",
+      "required": ["start_line", "end_line"],
+      "properties": {
+        "start_line": { "type": "integer", "minimum": 1 },
+        "end_line": { "type": "integer", "minimum": 1 },
+        "content_hash": { "type": "string" },
+        "contributor": { "$ref": "#/$defs/contributor" }
+      }
+    }
+  }
+}

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.masondelan/selvedge",
   "title": "Selvedge",
   "description": "Long-term memory for AI-coded codebases — agents log the why behind every change and read it back.",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "websiteUrl": "https://selvedge.sh",
   "repository": {
     "url": "https://github.com/masondelan/selvedge",
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "selvedge",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "runtimeHint": "uvx",
       "runtimeArguments": [
         {

--- a/tests/test_agent_trace_export.py
+++ b/tests/test_agent_trace_export.py
@@ -1,0 +1,479 @@
+"""Tests for Selvedge ↔ Agent Trace v0.1.0 interop.
+
+Covers the pure converter (selvedge.exporters.agent_trace) and the CLI
+surface (`selvedge export --format agent-trace`, `selvedge import
+--format agent-trace`). Never touches the real DB — CLI tests use the
+SELVEDGE_DB env override into a tmp_path.
+"""
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from selvedge.cli import cli
+from selvedge.config import get_db_path
+from selvedge.exporters.agent_trace import (
+    AGENT_TRACE_VERSION,
+    SELVEDGE_NS,
+    event_to_trace_record,
+    events_to_trace_records,
+    export_preamble,
+    extract_line_ranges,
+    load_trace_records,
+    trace_record_to_event,
+    trace_record_to_events,
+    validate_trace_record,
+)
+from selvedge.models import ChangeEvent
+from selvedge.storage import SelvedgeStorage
+
+
+def make_event(**overrides) -> dict:
+    """A ChangeEvent-shaped dict with sensible defaults, overridable per test."""
+    base = {
+        "id": str(uuid.uuid4()),
+        "timestamp": "2026-06-22T10:00:00Z",
+        "entity_type": "function",
+        "entity_path": "src/auth.py::login",
+        "change_type": "modify",
+        "diff": "@@ -40,3 +42,5 @@\n+a\n+b",
+        "reasoning": "Add a 2FA gate to the login path.",
+        "agent": "claude-code",
+        "session_id": "session-1",
+        "git_commit": "abc1234",
+        "project": "api",
+        "changeset_id": "add-2fa",
+        "metadata": '{"pr": 7}',
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# line-range extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_single_hunk():
+    assert extract_line_ranges("@@ -40,3 +42,5 @@\n+x") == [{"start_line": 42, "end_line": 46}]
+
+
+def test_extract_multiple_hunks():
+    diff = "@@ -1,2 +1,3 @@\n+a\n@@ -10,1 +12,2 @@\n+b"
+    assert extract_line_ranges(diff) == [
+        {"start_line": 1, "end_line": 3},
+        {"start_line": 12, "end_line": 13},
+    ]
+
+
+def test_extract_single_line_hunk_no_count():
+    # "+5" with no count means a 1-line range.
+    assert extract_line_ranges("@@ -5 +5 @@\n+x") == [{"start_line": 5, "end_line": 5}]
+
+
+def test_extract_no_hunks():
+    assert extract_line_ranges("CREATE TABLE users (id INT);") == []
+    assert extract_line_ranges("") == []
+
+
+# ---------------------------------------------------------------------------
+# ChangeEvent -> Agent Trace
+# ---------------------------------------------------------------------------
+
+
+def test_file_event_maps_to_files_with_ranges():
+    rec = event_to_trace_record(make_event(), tool_version="0.3.9")
+    assert rec["version"] == AGENT_TRACE_VERSION
+    assert rec["tool"] == {"name": "selvedge", "version": "0.3.9"}
+    assert rec["vcs"] == {"type": "git", "revision": "abc1234"}
+    assert len(rec["files"]) == 1
+    f = rec["files"][0]
+    assert f["path"] == "src/auth.py"  # ::login stripped
+    conv = f["conversations"][0]
+    assert conv["contributor"] == {"type": "ai"}
+    assert conv["ranges"] == [{"start_line": 42, "end_line": 46}]
+    assert conv["related"] == [{"type": "changeset", "url": "urn:selvedge:changeset:add-2fa"}]
+    sv = rec["metadata"][SELVEDGE_NS]
+    assert sv["entity"] == "src/auth.py::login"
+    assert sv["reasoning"] == "Add a 2FA gate to the login path."
+    assert sv["range_unknown"] is False
+    assert sv["metadata"] == {"pr": 7}
+
+
+def test_non_file_event_has_empty_files_and_metadata():
+    ev = make_event(entity_type="column", entity_path="users.email", diff="", changeset_id="")
+    rec = event_to_trace_record(ev)
+    assert rec["files"] == []
+    sv = rec["metadata"][SELVEDGE_NS]
+    assert sv["entity"] == "users.email"
+    assert sv["entity_type"] == "column"
+    assert sv["range_unknown"] is True
+
+
+def test_contributor_unknown_when_no_agent():
+    rec = event_to_trace_record(make_event(agent=""))
+    assert rec["files"][0]["conversations"][0]["contributor"] == {"type": "unknown"}
+
+
+def test_no_vcs_without_commit():
+    rec = event_to_trace_record(make_event(git_commit=""))
+    assert "vcs" not in rec
+
+
+def test_non_uuid_id_becomes_deterministic_uuid():
+    rec1 = event_to_trace_record(make_event(id="not-a-uuid"))
+    rec2 = event_to_trace_record(make_event(id="not-a-uuid"))
+    uuid.UUID(rec1["id"])  # parses
+    assert rec1["id"] == rec2["id"]  # deterministic
+
+
+# ---------------------------------------------------------------------------
+# validation + vendored schema
+# ---------------------------------------------------------------------------
+
+
+def test_emitted_records_pass_validation():
+    for ev in (make_event(), make_event(entity_type="column", entity_path="users.email", diff="")):
+        assert validate_trace_record(event_to_trace_record(ev)) == []
+
+
+def test_validation_catches_bad_records():
+    assert "version must be '0.1.0'" in " ".join(validate_trace_record({"version": "9.9.9"}))
+    bad = event_to_trace_record(make_event())
+    bad["files"][0]["conversations"][0]["ranges"][0]["start_line"] = 0
+    problems = validate_trace_record(bad)
+    assert any("start_line" in p for p in problems)
+    assert validate_trace_record("not a dict") == ["record is not an object"]
+
+
+def test_vendored_schema_matches_validator_required_fields():
+    schema_path = Path(__file__).resolve().parent.parent / "selvedge" / "exporters" / "agent_trace_schema.json"
+    schema = json.loads(schema_path.read_text())
+    assert schema["required"] == ["version", "id", "timestamp", "files"]
+    # A record missing a top-level required field fails our validator too.
+    rec = event_to_trace_record(make_event())
+    del rec["timestamp"]
+    assert any("timestamp" in p for p in validate_trace_record(rec))
+
+
+# ---------------------------------------------------------------------------
+# round-trip (Agent Trace -> ChangeEvent)
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_file_event():
+    ev = make_event()
+    back = trace_record_to_event(event_to_trace_record(ev))
+    for key in ("entity_path", "change_type", "reasoning", "agent", "session_id",
+                "project", "changeset_id", "entity_type"):
+        assert back[key] == ev[key], key
+    assert back["git_commit"] == ev["git_commit"]
+
+
+def test_roundtrip_non_file_entity_preserved():
+    ev = make_event(entity_type="column", entity_path="users.email", diff="")
+    back = trace_record_to_event(event_to_trace_record(ev))
+    assert back["entity_path"] == "users.email"
+    assert back["entity_type"] == "column"
+    assert back["change_type"] == ev["change_type"]
+    assert back["reasoning"] == ev["reasoning"]
+    # Reconstructable as a real ChangeEvent.
+    rebuilt = ChangeEvent(**back)
+    assert rebuilt.entity_path == "users.email"
+
+
+def test_foreign_record_imports_best_effort():
+    foreign = {
+        "version": "0.1.0",
+        "id": str(uuid.uuid4()),
+        "timestamp": "2026-06-22T10:00:00Z",
+        "files": [{"path": "src/x.ts", "conversations": [
+            {"contributor": {"type": "ai", "model_id": "openai/gpt-4o"}, "ranges": []}
+        ]}],
+    }
+    ev = trace_record_to_event(foreign)
+    assert ev is not None
+    assert ev["entity_path"] == "src/x.ts"
+    assert ev["change_type"] == "modify"
+    assert ev["reasoning"] == ""
+    assert ev["agent"] == "ai"
+    ChangeEvent(**ev)  # constructs without error
+
+
+def test_record_with_no_usable_entity_is_skipped():
+    assert trace_record_to_event({"version": "0.1.0", "id": str(uuid.uuid4()),
+                                  "timestamp": "2026-06-22T10:00:00Z", "files": []}) is None
+
+
+def test_reasoning_quality_passthrough():
+    # Weak/empty reasoning is preserved verbatim, not "fixed".
+    for reasoning in ("", "fix", "done"):
+        ev = make_event(reasoning=reasoning)
+        rec = event_to_trace_record(ev)
+        assert rec["metadata"][SELVEDGE_NS]["reasoning"] == reasoning
+        assert trace_record_to_event(rec)["reasoning"] == reasoning
+
+
+# ---------------------------------------------------------------------------
+# collapse-by-session
+# ---------------------------------------------------------------------------
+
+
+def test_collapse_by_session():
+    rows = [make_event(id=str(uuid.uuid4()), entity_path=f"src/m{i}.py", entity_type="file",
+                       session_id="S") for i in range(5)]
+    collapsed = events_to_trace_records(rows, collapse_by_session=True)
+    assert len(collapsed) == 1
+    sv = collapsed[0]["metadata"][SELVEDGE_NS]
+    assert sv["collapsed"] is True
+    assert sv["event_count"] == 5
+    assert len(sv["events"]) == 5
+    assert validate_trace_record(collapsed[0]) == []
+
+    separate = events_to_trace_records(rows, collapse_by_session=False)
+    assert len(separate) == 5
+
+
+def test_collapse_keeps_sessionless_events_separate():
+    rows = [
+        make_event(id=str(uuid.uuid4()), session_id="S", entity_path="src/a.py", entity_type="file"),
+        make_event(id=str(uuid.uuid4()), session_id="S", entity_path="src/b.py", entity_type="file"),
+        make_event(id=str(uuid.uuid4()), session_id="", entity_path="src/c.py", entity_type="file"),
+    ]
+    records = events_to_trace_records(rows, collapse_by_session=True)
+    assert len(records) == 2  # one merged session + one standalone
+
+
+# ---------------------------------------------------------------------------
+# bundle / NDJSON loading
+# ---------------------------------------------------------------------------
+
+
+def test_load_records_from_bundle_array_single_and_ndjson():
+    rec = event_to_trace_record(make_event())
+    header = export_preamble()[SELVEDGE_NS]
+    assert len(load_trace_records(json.dumps({**header, "records": [rec, rec]}))) == 2
+    assert len(load_trace_records(json.dumps([rec, rec]))) == 2
+    assert len(load_trace_records(json.dumps(rec))) == 1
+    assert len(load_trace_records(json.dumps(rec) + "\n" + json.dumps(rec))) == 2
+    assert load_trace_records("") == []
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("SELVEDGE_DB", str(tmp_path / "selvedge.db"))
+    import selvedge.server as srv
+    srv._storage = None
+    yield
+    srv._storage = None
+
+
+def _seed(entity="users.email", change_type="add", **kw):
+    storage = SelvedgeStorage(get_db_path())
+    storage.log_event(ChangeEvent(entity_path=entity, change_type=change_type, **kw))
+
+
+def test_cli_export_agent_trace_bundle(runner, tmp_path):
+    _seed(entity="users.email", change_type="add", reasoning="add email column", git_commit="c0ffee")
+    _seed(entity="src/auth.py::login", change_type="modify", entity_type="function",
+          diff="@@ -1,2 +1,3 @@\n+x", reasoning="harden login")
+    out = tmp_path / "trace.json"
+    result = runner.invoke(cli, ["export", "--format", "agent-trace", "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    bundle = json.loads(out.read_text())
+    assert bundle["agent_trace_version"] == AGENT_TRACE_VERSION
+    assert "selvedge" in bundle["producer"]
+    assert len(bundle["records"]) == 2
+    for rec in bundle["records"]:
+        assert validate_trace_record(rec) == []
+
+
+def test_cli_export_agent_trace_ndjson(runner):
+    _seed()
+    _seed(entity="src/x.py", entity_type="file", change_type="modify")
+    result = runner.invoke(cli, ["export", "--format", "agent-trace", "--ndjson"])
+    assert result.exit_code == 0, result.output
+    lines = [ln for ln in result.output.strip().splitlines() if ln.strip()]
+    assert len(lines) == 2
+    for line in lines:
+        assert validate_trace_record(json.loads(line)) == []
+
+
+def test_cli_export_collapse_by_session(runner):
+    for i in range(3):
+        _seed(entity=f"src/m{i}.py", entity_type="file", change_type="modify", session_id="sess")
+    result = runner.invoke(cli, ["export", "--format", "agent-trace", "--collapse-by-session"])
+    assert result.exit_code == 0, result.output
+    bundle = json.loads(result.output)
+    assert len(bundle["records"]) == 1
+    assert bundle["records"][0]["metadata"][SELVEDGE_NS]["event_count"] == 3
+
+
+def test_cli_import_agent_trace_roundtrip(runner, tmp_path, monkeypatch):
+    _seed(entity="users.email", change_type="add", reasoning="add email column")
+    _seed(entity="deps/stripe", change_type="add", entity_type="dependency", reasoning="pin stripe")
+    out = tmp_path / "trace.json"
+    assert runner.invoke(cli, ["export", "--format", "agent-trace", "-o", str(out)]).exit_code == 0
+
+    # Fresh DB, then import the trace back.
+    monkeypatch.setenv("SELVEDGE_DB", str(tmp_path / "fresh.db"))
+    import selvedge.server as srv
+    srv._storage = None
+    result = runner.invoke(cli, ["import", str(out), "--format", "agent-trace"])
+    assert result.exit_code == 0, result.output
+
+    history = SelvedgeStorage(get_db_path()).get_history(limit=100)
+    entities = {e["entity_path"] for e in history}
+    assert {"users.email", "deps/stripe"} <= entities
+
+
+def test_cli_import_agent_trace_dry_run_json(runner, tmp_path):
+    _seed(entity="users.email", change_type="add")
+    out = tmp_path / "trace.json"
+    runner.invoke(cli, ["export", "--format", "agent-trace", "-o", str(out)])
+    result = runner.invoke(cli, ["import", str(out), "--format", "agent-trace", "--json"])
+    assert result.exit_code == 0, result.output
+    events = json.loads(result.output)
+    assert any(e["entity_path"] == "users.email" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# regression tests for the adversarial-review findings
+# ---------------------------------------------------------------------------
+
+
+def test_validator_contributor_optional_ranges_required():
+    # contributor is optional at the conversation level (can be per-range)
+    rec = event_to_trace_record(make_event())
+    conv = rec["files"][0]["conversations"][0]
+    del conv["contributor"]
+    conv["ranges"] = [{"start_line": 1, "end_line": 2, "contributor": {"type": "ai"}}]
+    assert validate_trace_record(rec) == []
+    # ranges is required
+    rec2 = event_to_trace_record(make_event())
+    del rec2["files"][0]["conversations"][0]["ranges"]
+    assert any("ranges is required" in p for p in validate_trace_record(rec2))
+    # a bad per-range contributor type is caught
+    rec3 = event_to_trace_record(make_event())
+    rec3["files"][0]["conversations"][0]["ranges"][0]["contributor"] = {"type": "robot"}
+    assert any("contributor.type" in p for p in validate_trace_record(rec3))
+
+
+def test_validator_requires_vcs_revision():
+    rec = event_to_trace_record(make_event())  # has vcs with a revision
+    del rec["vcs"]["revision"]
+    assert any("revision" in p for p in validate_trace_record(rec))
+
+
+def test_vendored_schema_nested_required_lists():
+    schema_path = Path(__file__).resolve().parent.parent / "selvedge" / "exporters" / "agent_trace_schema.json"
+    schema = json.loads(schema_path.read_text())
+    file_items = schema["properties"]["files"]["items"]
+    assert set(file_items["required"]) == {"path", "conversations"}
+    conv_items = file_items["properties"]["conversations"]["items"]
+    assert conv_items["required"] == ["ranges"]
+
+
+def test_invalid_change_type_coerced_to_modify():
+    rec = event_to_trace_record(make_event())
+    rec["metadata"][SELVEDGE_NS]["change_type"] = "edit"  # not a valid ChangeType
+    ev = trace_record_to_event(rec)
+    assert ev["change_type"] == "modify"
+    ChangeEvent(**ev)  # would raise if change_type were left as "edit"
+
+
+def test_non_dict_metadata_roundtrips():
+    for raw in ("[1, 2, 3]", '"scalar"', "0"):
+        ev = make_event(metadata=raw)
+        back = trace_record_to_event(event_to_trace_record(ev))
+        assert json.loads(back["metadata"]) == json.loads(raw)
+
+
+def test_foreign_multi_file_record_fans_out():
+    rec = {
+        "version": "0.1.0", "id": str(uuid.uuid4()), "timestamp": "2026-06-22T10:00:00Z",
+        "files": [
+            {"path": "a.py", "conversations": [{"contributor": {"type": "ai"}, "ranges": []}]},
+            {"path": "b.py", "conversations": [{"contributor": {"type": "ai"}, "ranges": []}]},
+        ],
+    }
+    events = trace_record_to_events(rec)
+    assert {e["entity_path"] for e in events} == {"a.py", "b.py"}
+    assert len({e["id"] for e in events}) == 2  # distinct ids, no PK collision
+
+
+def test_foreign_idless_records_get_distinct_ids():
+    base = {"version": "0.1.0", "timestamp": "2026-06-22T10:00:00Z"}
+    r1 = dict(base, files=[{"path": "a.py", "conversations": [{"contributor": {"type": "ai"}, "ranges": []}]}])
+    r2 = dict(base, files=[{"path": "b.py", "conversations": [{"contributor": {"type": "ai"}, "ranges": []}]}])
+    assert trace_record_to_events(r1)[0]["id"] != trace_record_to_events(r2)[0]["id"]
+
+
+def test_collapsed_record_roundtrips():
+    rows = [
+        make_event(id=str(uuid.uuid4()), session_id="S", entity_type="file",
+                   entity_path="src/a.py", reasoning="reason A", change_type="add"),
+        make_event(id=str(uuid.uuid4()), session_id="S", entity_type="function",
+                   entity_path="src/b.py::foo", reasoning="reason B", change_type="modify"),
+        make_event(id=str(uuid.uuid4()), session_id="S", entity_type="env_var",
+                   entity_path="env/X", reasoning="reason C", change_type="add", diff=""),
+    ]
+    collapsed = events_to_trace_records(rows, collapse_by_session=True)
+    assert len(collapsed) == 1
+    back = trace_record_to_events(collapsed[0])
+    assert len(back) == 3
+    by_entity = {e["entity_path"]: e for e in back}
+    assert set(by_entity) == {"src/a.py", "src/b.py::foo", "env/X"}
+    assert by_entity["src/b.py::foo"]["reasoning"] == "reason B"
+    assert by_entity["env/X"]["change_type"] == "add"
+    assert all(e["session_id"] == "S" for e in back)
+    assert len({e["id"] for e in back}) == 3  # unique ids
+    for e in back:
+        ChangeEvent(**e)  # all reconstruct cleanly
+
+
+def test_collapse_merge_semantics():
+    rows = [
+        make_event(id=str(uuid.uuid4()), session_id="S", entity_path="src/a.py",
+                   entity_type="file", timestamp="2026-06-22T12:00:00Z", git_commit=""),
+        make_event(id=str(uuid.uuid4()), session_id="S", entity_path="src/a.py",
+                   entity_type="file", timestamp="2026-06-22T09:00:00Z", git_commit="deadbee"),
+        make_event(id=str(uuid.uuid4()), session_id="S", entity_path="src/b.py",
+                   entity_type="file", timestamp="2026-06-22T15:00:00Z", git_commit="f00d"),
+    ]
+    rec = events_to_trace_records(rows, collapse_by_session=True)[0]
+    assert rec["timestamp"] == "2026-06-22T09:00:00Z"          # min, even out of order
+    assert rec["vcs"] == {"type": "git", "revision": "deadbee"}  # first event WITH a commit
+    files = {f["path"]: f for f in rec["files"]}
+    assert set(files) == {"src/a.py", "src/b.py"}
+    assert len(files["src/a.py"]["conversations"]) == 2          # same path merged
+    assert len(files["src/b.py"]["conversations"]) == 1
+
+
+def test_cli_import_collapsed_roundtrip(runner, tmp_path, monkeypatch):
+    for i in range(3):
+        _seed(entity=f"src/m{i}.py", entity_type="file", change_type="modify",
+              session_id="sess", reasoning=f"reason {i}")
+    out = tmp_path / "trace.json"
+    assert runner.invoke(
+        cli, ["export", "--format", "agent-trace", "--collapse-by-session", "-o", str(out)]
+    ).exit_code == 0
+    monkeypatch.setenv("SELVEDGE_DB", str(tmp_path / "fresh.db"))
+    import selvedge.server as srv
+    srv._storage = None
+    assert runner.invoke(cli, ["import", str(out), "--format", "agent-trace"]).exit_code == 0
+    entities = {e["entity_path"] for e in SelvedgeStorage(get_db_path()).get_history(limit=100)}
+    assert {"src/m0.py", "src/m1.py", "src/m2.py"} <= entities  # all 3 survived collapse


### PR DESCRIPTION
## Agent Trace v0.1.0 export + import (item 5 of the launch handoff)

Implements `selvedge export --format agent-trace` (and the inverse `selvedge import --format agent-trace`) so Selvedge's captured history travels to any tool that reads [Agent Trace](https://github.com/cursor/agent-trace) — the open AI code-attribution wire format from Cursor + Cognition AI. Selvedge stays the live capture + query layer; Agent Trace is just an opt-in export format.

### What's here
- **`selvedge.exporters.agent_trace`** — pure, no-LLM, dependency-free converter both directions (`event_to_trace_record` / `trace_record_to_events`), unified-diff line-range extraction, `--collapse-by-session` merge, a hand-rolled `validate_trace_record` (no `jsonschema` dep), and a vendored v0.1.0 JSON Schema.
- **CLI**: `selvedge export --format agent-trace [--ndjson] [--collapse-by-session]`; `selvedge import <file> --format agent-trace`.
- **35 tests** (`tests/test_agent_trace_export.py`): round-trip, non-file entity preservation, line-range extraction, collapse round-trip, reasoning-quality passthrough, schema validation, foreign-record fan-out, CLI integration.
- Version bumped to **0.3.9** across all five files; CHANGELOG + README + `docs/agent-trace-interop.md` updated.
- Full gate green locally: `pytest` (562 passed), `ruff check`, `mypy selvedge/`.

### Two decisions worth a look

**1. Version semantics — shipped as 0.3.9, not 0.4.0.** The interop doc originally targeted this for **v0.4.0 (Phase 3, alongside Postgres + HTTP)**. Per the handoff ("Decision default = DO IT"), it's pulled forward — but releasing it *as* 0.4.0 would falsely imply Postgres/HTTP landed, so it ships as a **0.3.9** opt-in, additive feature. Postgres + the HTTP layer remain the v0.4.0 markers. Flag if you'd rather it wait for 0.4.0.

**2. The repo's interop doc was wrong about the wire format.** `docs/agent-trace-interop.md` described `files[].ranges[]` + top-level `contributors[]` + `extensions`. The **real** v0.1.0 spec (verified against cursor/agent-trace's authoritative Zod `schemas.ts`) is `files[].conversations[].ranges[]`, optional `contributor`, required `ranges`, and vendor data in `metadata` under reverse-domain keys. This PR implements the **real** spec and corrects the doc; the producer output validates against it.

### Adversarial review caught (and this PR fixes) real bugs
A multi-agent review against the upstream Zod source found genuine issues, all fixed here with regression tests: conversation `contributor`/`ranges` requiredness was inverted in the validator + vendored schema; `--collapse-by-session` exports didn't round-trip (N→1 data loss); id-less foreign records collided on the primary key and aborted import; foreign multi-file records truncated to the first file; an unknown `change_type` silently dropped the event; list/scalar `metadata` was rewrapped; the validator skipped `vcs.revision`.

### ⚠️ Held for explicit go/no-go (intentionally not done in this autonomous run)
These are the irreversible / outward-facing steps; everything above is reversible and staged green:
- **Tagging `v0.3.9`** (CI publishes to PyPI + the MCP Registry — permanent, a version can't be reused). Merge + tag when you're happy.
- **The external PR to `cursor/agent-trace`** adding Selvedge to their compatible-producers list — represents the project to a third party; left for you to send.
- **Site sync** (`compare/agent-trace.md` has the old simplified mapping) should land *with* the release, so it's deferred to avoid claiming "shipped in 0.3.9" on the live site before PyPI has it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
