### PR TITLE
build(docker): add Dockerfile for the Docker MCP Catalog submission

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Keep the Docker MCP Catalog image lean — pip builds the wheel from pyproject
+# (the selvedge/ package only), so none of this needs to land in the build
+# context. Excluding .git in particular keeps the whole history out of the image.
+.git
+.github
+tests
+launch
+docs
+demos
+*.pyc
+__pycache__
+.venv
+.mypy_cache
+.ruff_cache
+.pytest_cache
+htmlcov
+dist
+build
+*.egg-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+#
+# Container image for the Selvedge MCP server — used by the Docker MCP Catalog
+# (https://github.com/docker/mcp-registry). The catalog builds this image from
+# the pinned `source.commit` in its servers/selvedge/server.yaml, so the image
+# matches that commit exactly. It runs `selvedge-server` over stdio: no network,
+# no telemetry, all history in a local SQLite file under .selvedge/.
+#
+# Native installs (`pip install selvedge` / `uvx --from selvedge selvedge-server`)
+# remain the primary path; this Dockerfile exists so Selvedge can also be a
+# one-command install inside Docker Desktop's MCP Toolkit.
+
+FROM python:3.12-slim
+
+# Selvedge has a small, declared dependency set and no build-time native deps.
+# Install from the checked-out source so the image content == the pinned commit.
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir .
+
+# selvedge-server speaks MCP over stdio. With no project mounted, SELVEDGE_DB
+# defaults to ~/.selvedge/selvedge.db inside the container; mount a project (see
+# the run.volumes block in the catalog server.yaml) to use its .selvedge/ store.
+ENTRYPOINT ["selvedge-server"]


### PR DESCRIPTION
Adds a minimal stdio-server `Dockerfile` (+ `.dockerignore`) so Selvedge can be submitted to the Docker MCP Catalog (docker/mcp-registry).

The registry only lists **containerized (local)** or **remote** servers — there's no pip/uvx runner type — so the submission goes via Option A: omit `image:` in the catalog `server.yaml` and Docker builds, signs, and publishes `mcp/selvedge` from this Dockerfile at the pinned `source.commit`. Builds Selvedge from source so the image matches the commit exactly. Native pip/uvx installs remain primary.

**Merge to main is the prerequisite** for the docker/mcp-registry PR: its `server.yaml` pins a commit on this repo's default branch. After merge, the catalog `server.yaml` (staged at `launch/listings/docker-mcp-catalog/`) gets that SHA.