### PR TITLE
docs(readme): link 'Add to Cursor / VS Code' to the site install buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ docs/release-content/
 docs/mcp-registry-submission.md
 docs/strategy-2026-q3.md
 docs/top-priority-actions.md
+docs/growth-master-plan.md
 docs/seo-gsc-primer.md
 docs/marketing-templates.md
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
 </p>
 
+<p align="center"><sub><b>One-click install:</b> <a href="https://selvedge.sh/mcp/cursor/">Add to Cursor</a> &nbsp;·&nbsp; <a href="https://selvedge.sh/mcp/vscode/">Install in VS Code</a> — the deeplink buttons live on the site, where they resolve in your browser (a raw <code>cursor://</code> link can't open from GitHub's web README).</sub></p>
+
 <!-- mcp-name: io.github.masondelan/selvedge -->
 
 **Long-term memory for AI-coded codebases.**


### PR DESCRIPTION
Replaces #14 (which wrongly also committed the internal growth plan to this public repo — see below).

- **README** — link "Add to Cursor / VS Code" to the per-editor pages on selvedge.sh instead of re-embedding a `cursor://` deeplink that dead-ends from GitHub's web README. Closes the conversion-gap regression from 56d0615.
- **.gitignore** — add `docs/growth-master-plan.md` to the internal-docs ignore list, alongside `strategy-2026-q3.md` / `engagement-strategy.md` / `top-priority-actions.md`. The growth plan is internal strategy and stays a **local** mirror (Notion is the working copy); it must not be public.

**Site sync:** paired PR masondelan/selvedge-site#4 restores the one-click buttons (Cursor `cursor.com/install-mcp`, VS Code `vscode.dev/redirect`), both verified live.