### PR TITLE
chore(gitignore): keep docs/growth-master-plan.md local-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ docs/release-content/
 docs/mcp-registry-submission.md
 docs/strategy-2026-q3.md
 docs/top-priority-actions.md
+docs/growth-master-plan.md
 docs/seo-gsc-primer.md
 docs/marketing-templates.md
 


### PR DESCRIPTION
Adds `docs/growth-master-plan.md` to the internal-docs ignore list, alongside `strategy-2026-q3.md` / `engagement-strategy.md` / `top-priority-actions.md`. The growth master plan is internal strategy — it stays a **local** mirror (Notion is the working copy) and must never be committed to this public repo. This is the protective remainder of the closed #14/#16; no README or site changes.